### PR TITLE
Add types for int / uint 8, 16, 32, 64, float 32 and 64

### DIFF
--- a/data/tree.go
+++ b/data/tree.go
@@ -11,15 +11,15 @@ import (
 
 type (
 	node struct {
-		t        pkg.FieldType
-		nullable pkg.Nullable
-		mutex    sync.RWMutex
 		id       uint64
 		min      uint64
 		max      uint64
-		version  uint
+		t        pkg.FieldType // 32
+		v        interface{} // 16
 		name     string
-		v        interface{}
+		version  uint          // 32
+		mutex    sync.RWMutex
+		nullable pkg.Nullable
 		parent   pkg.Composer
 		next     pkg.Composer
 		prev     pkg.Composer
@@ -81,6 +81,7 @@ func Index(b bool) Opt {
 }
 
 // Set the nullable property of a node
+// nullable is copied NOT referenced by the node
 func Nullable(nullable *pkg.Nullable) Opt {
 	return func(n *node) (*node, error) {
 		n.nullable = *nullable
@@ -89,6 +90,7 @@ func Nullable(nullable *pkg.Nullable) Opt {
 }
 
 // Add the type [t] of value held by this node.
+// t is copied NOT referenced by the node
 func Type(t *pkg.FieldType) Opt {
 	return func(n *node) (*node, error) {
 		n.t = *t
@@ -127,6 +129,8 @@ func (i *node) Value() interface{} {
 }
 
 // Get a nodes children
+// returns a reference to the children map
+// The child should NOT be mutated, a reference is used to mitigate a potentially large copy operation
 func (i *node) Children() *map[uint64]pkg.Composer {
 	return &i.children
 }
@@ -374,6 +378,7 @@ func (i *node) Excludes() []bool {
 func (i *node) Nullable() pkg.Nullable {
 	return i.nullable
 }
+
 // func (i *node) LockWhile(fn func()) {
 // 	n := root(i)
 // 	n.mutex.RLock()

--- a/io/input/common.go
+++ b/io/input/common.go
@@ -2,8 +2,9 @@ package input
 
 import (
 	"encoding/csv"
-	"github.com/loanpal-engineering/exttra/types"
 	"io"
+
+	"github.com/loanpal-engineering/exttra/types"
 )
 
 type (

--- a/io/input/flat_file.go
+++ b/io/input/flat_file.go
@@ -37,3 +37,4 @@ func Csv(source io.Reader, def types.Signature) Input {
 	i.reader.ReuseRecord = true
 	return i
 }
+

--- a/io/output/flat_file.go
+++ b/io/output/flat_file.go
@@ -84,7 +84,7 @@ func (i *FlatFile) Flush() error {
 	column := make(chan pkg.Pair)
 	sent := 0
 	complete := 0
-	for id, v := range root.Children() {
+	for id, v := range *root.Children() {
 		if pkg.IsNil(v) || root.Null()[id] {
 			continue
 		}
@@ -103,7 +103,7 @@ func (i *FlatFile) Flush() error {
 				i.header = rows[0]
 				err := writer.WriteAll(rows)
 				if err != nil {
-					pkg.FatalDefect(&pkg.Defect{
+					pkg.FatalDefect(pkg.Defect{
 						Msg: err.Error(),
 					})
 				}
@@ -171,7 +171,7 @@ func (i *FlatFile) buildColumn(out chan pkg.Pair, n pkg.Composer, colIdx int) {
 		format = f
 	}
 	excludes := i.src.(pkg.Editor).Excludes()
-	for _, v := range n.Children() {
+	for _, v := range *n.Children() {
 		_, _, row := v.Id()
 		if excludes[row] {
 			continue

--- a/io/output/mem.go
+++ b/io/output/mem.go
@@ -51,8 +51,8 @@ func (i *Memory) leftMostNode() (pkg.Composer, error) {
 	// Left most node in the tree
 	var lhs pkg.Composer
 	// Doesnt matter which child, just pick one
-	for id := range i.src.Children() {
-		lhs = i.src.Children()[id]
+	for id := range *i.src.Children() {
+		lhs = (*i.src.Children())[id]
 		break
 	}
 	if lhs == nil {
@@ -98,7 +98,7 @@ func (i *Memory) Flush() error {
 		return err
 	}
 	excludes := i.src.(pkg.Editor).Excludes()
-	for _, v := range lhs.Children() {
+	for _, v := range *lhs.Children() {
 		_, _, row := v.Id()
 		if excludes[row] {
 			continue

--- a/io/output/mem.go
+++ b/io/output/mem.go
@@ -191,6 +191,10 @@ func (i *Memory) fillShape(out chan interface{}, quit chan error, n pkg.Composer
 			if field.Type.Kind() == reflect.Float64 {
 				cpy.FieldByIndex(field.Index).SetFloat(n.Value().(float64))
 			}
+		case float32:
+			if field.Type.Kind() == reflect.Float32 {
+				cpy.FieldByIndex(field.Index).Set(reflect.ValueOf(n.Value().(float32)))
+			}
 		case bool:
 			if field.Type.Kind() == reflect.Bool {
 				cpy.FieldByIndex(field.Index).SetBool(n.Value().(bool))
@@ -204,6 +208,34 @@ func (i *Memory) fillShape(out chan interface{}, quit chan error, n pkg.Composer
 		case int64:
 			if field.Type.Kind() == reflect.Int64 {
 				cpy.FieldByIndex(field.Index).SetInt(n.Value().(int64))
+			}
+		case int32:
+			if field.Type.Kind() == reflect.Int32 {
+				cpy.FieldByIndex(field.Index).Set(reflect.ValueOf(n.Value().(int32)))
+			}
+		case int16:
+			if field.Type.Kind() == reflect.Int16 {
+				cpy.FieldByIndex(field.Index).Set(reflect.ValueOf(n.Value().(int16)))
+			}
+		case int8:
+			if field.Type.Kind() == reflect.Int8 {
+				cpy.FieldByIndex(field.Index).Set(reflect.ValueOf(n.Value().(int8)))
+			}
+		case uint64:
+			if field.Type.Kind() == reflect.Uint64 {
+				cpy.FieldByIndex(field.Index).SetUint(n.Value().(uint64))
+			}
+		case uint32:
+			if field.Type.Kind() == reflect.Uint32 {
+				cpy.FieldByIndex(field.Index).Set(reflect.ValueOf(n.Value().(uint32)))
+			}
+		case uint16:
+			if field.Type.Kind() == reflect.Uint16 {
+				cpy.FieldByIndex(field.Index).Set(reflect.ValueOf(n.Value().(uint16)))
+			}
+		case uint8:
+			if field.Type.Kind() == reflect.Uint8 {
+				cpy.FieldByIndex(field.Index).Set(reflect.ValueOf(n.Value().(uint8)))
 			}
 		default:
 			quit <- errors.New("output/Memory: unknown type, supported types are: string, float64, int64, bool, time.Time")

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -149,12 +149,22 @@ func (p *parser) parseRow(row []string) error {
 						d.Msg = "parser/parse: time was expected"
 						n = nilNode
 					}
+				case pkg.FLOAT32:
+					switch item.(type) {
+					case float32:
+						n, err = data.NewNode(&id, data.V(item.(float32)))
+					default:
+						d.Msg = "parser/parse: float32 was expected"
+						n = nilNode
+					}
 				case pkg.FLOAT:
+					fallthrough
+				case pkg.FLOAT64:
 					switch item.(type) {
 					case float64:
 						n, err = data.NewNode(&id, data.V(item.(float64)))
 					default:
-						d.Msg = "parser/parse: float was expected"
+						d.Msg = "parser/parse: float64 was expected"
 						n = nilNode
 					}
 				case pkg.CUSTOM:
@@ -175,12 +185,72 @@ func (p *parser) parseRow(row []string) error {
 						d.Msg = "parser/parse: bool was expected"
 						n = nilNode
 					}
+				case pkg.UINT:
+					fallthrough
+				case pkg.UINT64:
+					switch item.(type) {
+					case uint64:
+						n, err = data.NewNode(&id, data.V(item.(uint64)))
+					default:
+						d.Msg = "parser/parse: uint64 was expected"
+						n = nilNode
+					}
 				case pkg.INT:
+					fallthrough
+				case pkg.INT64:
 					switch item.(type) {
 					case int64:
 						n, err = data.NewNode(&id, data.V(item.(int64)))
 					default:
-						d.Msg = "parser/parse: bool was expected"
+						d.Msg = "parser/parse: int64 was expected"
+						n = nilNode
+					}
+				case pkg.UINT32:
+					switch item.(type) {
+					case uint32:
+						n, err = data.NewNode(&id, data.V(item.(uint32)))
+					default:
+						d.Msg = "parser/parse: uint32 was expected"
+						n = nilNode
+					}
+				case pkg.INT32:
+					switch item.(type) {
+					case int32:
+						n, err = data.NewNode(&id, data.V(item.(int32)))
+					default:
+						d.Msg = "parser/parse: int32 was expected"
+						n = nilNode
+					}
+				case pkg.UINT16:
+					switch item.(type) {
+					case uint16:
+						n, err = data.NewNode(&id, data.V(item.(uint16)))
+					default:
+						d.Msg = "parser/parse: uint32 was expected"
+						n = nilNode
+					}
+				case pkg.INT16:
+					switch item.(type) {
+					case int16:
+						n, err = data.NewNode(&id, data.V(item.(int16)))
+					default:
+						d.Msg = "parser/parse: int16 was expected"
+						n = nilNode
+					}
+				case pkg.UINT8:
+					switch item.(type) {
+					case uint8:
+						n, err = data.NewNode(&id, data.V(item.(uint8)))
+					default:
+						d.Msg = "parser/parse: uint8 was expected"
+						n = nilNode
+					}
+				case pkg.INT8:
+					switch item.(type) {
+					case int8:
+						n, err = data.NewNode(&id, data.V(item.(int8)))
+					default:
+						d.Msg = "parser/parse: int8 was expected"
 						n = nilNode
 					}
 				default:
@@ -203,7 +273,7 @@ func (p *parser) parseRow(row []string) error {
 	}
 	return p.linkRow(colRow)
 }
-func (p *parser) linkRow(row []pkg.Composer)  error {
+func (p *parser) linkRow(row []pkg.Composer) error {
 	var (
 		i         = 0
 		err error = nil

--- a/pkg/common.go
+++ b/pkg/common.go
@@ -11,8 +11,20 @@ type (
 )
 
 const (
-	INT FieldType = iota
+	// INT FieldType = iota
+	INT8 FieldType = iota
+	INT16
+	INT
+	INT32
+	INT64
+	UINT8
+	UINT16
+	UINT
+	UINT32
+	UINT64
+	FLOAT32
 	FLOAT
+	FLOAT64
 	STRING
 	TIMESTAMP
 	DATE
@@ -23,5 +35,26 @@ const (
 )
 
 func (dt FieldType) String() string {
-	return [...]string{"INT", "FLOAT", "STRING", "TIMESTAMP", "DATE", "CUSTOM", "BOOL", "NULL", "UNKNOWN"}[dt]
+	return [...]string{
+		"INT8",
+		"INT16",
+		"INT",
+		"INT32",
+		"INT64",
+		"UINT8",
+		"UINT16",
+		"UINT",
+		"UINT32",
+		"UINT64",
+		"FLOAT32",
+		"FLOAT",
+		"FLOAT64",
+		"STRING",
+		"TIMESTAMP",
+		"DATE",
+		"CUSTOM",
+		"BOOL",
+		"NULL",
+		"UNKNOWN",
+	}[dt]
 }

--- a/pkg/data.go
+++ b/pkg/data.go
@@ -2,9 +2,9 @@ package pkg
 
 type (
 	Nullable struct {
-		Allowed     bool
 		Variants    []string
 		ReplaceWith *string
+		Allowed     bool
 	}
 	// Composer is the primary building block of the exttra tree
 	Composer interface {
@@ -13,9 +13,9 @@ type (
 		// Get the value of this node.
 		Value() interface{}
 		// Get the value type of this node.
-		T() *FieldType
+		T() FieldType
 		// Get this nodes children as a map[node id]node ptr.
-		Children() map[uint64]Composer
+		Children() *map[uint64]Composer
 		// Find a child node by either name of id.
 		// If id is available use [FindById].
 		// If the node is not found nil is returned.
@@ -50,7 +50,7 @@ type (
 		// manually via explicit manipulating a node nilmap (not advised).
 		Null() map[uint64]bool
 		// Get the nullability of a node
-		Nullable() *Nullable // Reset()
+		Nullable() Nullable // Reset()
 		// Is the child node at [id] excluded (not visible at output)
 		Excluded(id uint64) (bool, error)
 		// Find a child node by value. This method only works if the node was constructed with the functional option Index()
@@ -80,7 +80,7 @@ type (
 		// see [Parser]
 		Reset()
 		// LockWhile creates a read lock on the root node while the function is ran
-		LockWhile(func())
+		// LockWhile(func())
 	}
 	Defector interface {
 		Report(originalOffset int) [][]string // in csv format
@@ -88,17 +88,17 @@ type (
 		Count() int
 	}
 	Defects struct {
-		coll          []*Defect
 		exitInterrupt func([]*Defect)
 		Headers       []string
+		coll          []*Defect
 		enabled       bool
 	}
 	Opt    func(*Defects) (*Defects, error)
 	Defect struct {
 		Row  int
 		Col  int
-		Msg  string
 		Keys map[string]string
+		Msg  string
 	}
 )
 

--- a/pkg/data.go
+++ b/pkg/data.go
@@ -2,9 +2,9 @@ package pkg
 
 type (
 	Nullable struct {
-		Variants    []string
-		ReplaceWith *string
-		Allowed     bool
+		Variants    []string // 24
+		ReplaceWith *string  // 8
+		Allowed     bool     // 1
 	}
 	// Composer is the primary building block of the exttra tree
 	Composer interface {

--- a/pkg/defect.go
+++ b/pkg/defect.go
@@ -101,13 +101,13 @@ func (def *Defect) Error() string {
 // logging is NOT fatal, if a function uses LogDefect
 // it's the responsibility of the function implementation/caller
 // to set sentinel return value(s) and handle nils
-func LogDefect(d *Defect) {
+func LogDefect(d Defect) {
 	if d.Keys == nil {
 		d.Keys = map[string]string{}
 	}
 	defs := NewDC()
 	if defs.(*Defects).enabled {
-		defs.(*Defects).coll = append(defs.(*Defects).coll, d)
+		defs.(*Defects).coll = append(defs.(*Defects).coll, &d)
 	} else {
 		log.Printf("defect: %s", d.Msg)
 	}
@@ -117,13 +117,13 @@ func LogDefect(d *Defect) {
 // The defect will be added to the global defector object
 // To capture collected defects before the process exits
 // set the FatalExitInterrupt
-func FatalDefect(d *Defect) {
+func FatalDefect(d Defect) {
 	if d.Keys == nil {
 		d.Keys = map[string]string{}
 	}
 	defs := NewDC().(*Defects)
 	if defs.enabled {
-		defs.coll = append(defs.coll, d)
+		defs.coll = append(defs.coll, &d)
 		if defs.exitInterrupt != nil {
 			defs.exitInterrupt(defs.coll)
 		}

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -1,0 +1,122 @@
+package pkg
+//
+// import (
+// 	"errors"
+// 	"fmt"
+//
+// 	"github.com/loanpal-engineering/exttra/types"
+// )
+//
+// type (
+// 	NullFieldException struct {
+// 		field   Composer
+// 		message string
+// 	}
+// 	ColumnNotFoundException struct {
+// 		columnIdx uint32
+// 		message   string
+// 	}
+// 	ExpressionException struct {
+// 		message string
+// 		lhs     Composer
+// 		rhs     Composer
+// 	}
+// 	ConversionException struct {
+// 		message string
+// 		field   Composer
+// 		stage   types.Prop
+// 	}
+// )
+//
+// // Create a new NullFieldException
+// // An error message can be provided with details of the null field
+// func NewNullFieldException(field Composer) *NullFieldException {
+// 	_, col, row := field.Id()
+// 	// Get the column node
+// 	parent := field.Parent()
+// 	for {
+// 		if IsNil(parent.Parent()) {
+// 			break
+// 		} else {
+// 			parent = parent.Parent()
+// 		}
+// 	}
+// 	colName := parent.Name()
+// 	return &NullFieldException{
+// 		field:   field,
+// 		message: fmt.Sprintf("errors/NullFieldException: %s col=%d row=%d", colName, col, row),
+// 	}
+// }
+// func (e *NullFieldException) Unwrap() error {
+// 	return errors.New(e.message)
+// }
+// func (e *NullFieldException) Error() string {
+// 	return e.message
+// }
+//
+// // Create a new ColumnNotFoundException
+// func NewColumnNotFoundException(col uint32) *ColumnNotFoundException {
+// 	return &ColumnNotFoundException{
+// 		columnIdx: col,
+// 		message:   fmt.Sprintf("errors/ColumnNotFoundException: column %d not found", col),
+// 	}
+// }
+// func (e *ColumnNotFoundException) Error() string {
+// 	return e.message
+// }
+// func (e *ColumnNotFoundException) Unwrap() error {
+// 	return errors.New(e.message)
+// }
+// func NewExpressionException(lhs, rhs Composer, msg string) *ExpressionException {
+// 	_, lCol, lRow := lhs.Id()
+// 	_, rCol, rRow := rhs.Id()
+// 	lValue := lhs.Value()
+// 	rValue := rhs.Value()
+// 	return &ExpressionException{
+// 		message: fmt.Sprintf("errors/ExpressionException: lhs col=%d row=%d value=%v, rhs col=%d row=%d value=%v, %s",
+// 			lCol,
+// 			lRow,
+// 			lValue,
+// 			rCol,
+// 			rRow,
+// 			rValue,
+// 			msg),
+// 		lhs: lhs,
+// 		rhs: rhs,
+// 	}
+// }
+// func (e *ExpressionException) Error() string {
+// 	return e.message
+// }
+// func (e *ExpressionException) Unwrap() error {
+// 	return errors.New(e.message)
+// }
+// func NewConversionException(stage types.Prop, field Composer, msg string) *ConversionException {
+// 	var (
+// 		stageString string
+// 	)
+// 	switch stage {
+// 	case types.ToString:
+// 		stageString = "toString"
+// 	case types.Convert:
+// 		stageString = "convert"
+// 	case types.Extension:
+// 		stageString = "extension"
+// 	}
+// 	_, col, row := field.Id()
+// 	return &ConversionException{
+// 		message: fmt.Sprintf("errors/ConversionException: field col=%d row=%d on %s failure %s",
+// 			col,
+// 			row,
+// 			stageString,
+// 			msg),
+// 		field: field,
+// 		stage: stage,
+// 	}
+// }
+// func (e *ConversionException) Error() string {
+// 	return e.message
+// }
+// func (e *ConversionException) Unwrap() error {
+// 	return errors.New(e.message)
+// }

--- a/pkg/ops.go
+++ b/pkg/ops.go
@@ -51,11 +51,11 @@ func assertTypeIn(ts []FieldType, l, r Composer) (*FieldType, error) {
 		if rOk && lOk {
 			break
 		}
-		if l.T() != nil && *l.T() == tt {
+		if l.T() != UNKNOWN && l.T() == tt {
 			lt = tt
 			lOk = true
 		}
-		if r.T() != nil && *r.T() == tt {
+		if r.T() != UNKNOWN && r.T() == tt {
 			rt = tt
 			rOk = true
 		}
@@ -78,7 +78,7 @@ func applyToT(t interface{}, out chan map[uint32]interface{}, op func(l, r inter
 		fixed   = r.Max() == 0
 	)
 	excludes := l.(Editor).Excludes()
-	for _, ll := range l.Children() {
+	for _, ll := range *l.Children() {
 		var (
 			lv = ll.Value()
 			rv interface{}

--- a/pkg/ops.go
+++ b/pkg/ops.go
@@ -111,12 +111,102 @@ func applyToT(t interface{}, out chan map[uint32]interface{}, op func(l, r inter
 			} else {
 				results[row] = op(lv, rv)
 			}
+		case float32:
+			if _, ok := lv.(float32); !ok {
+				log.Printf("can not cast \"%v\" to float", lv)
+				results[row] = nil
+			} else if _, ok := rv.(float32); !ok {
+				log.Printf("can not cast \"%v\" to float", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
 		case float64:
 			if _, ok := lv.(float64); !ok {
 				log.Printf("can not cast \"%v\" to float", lv)
 				results[row] = nil
 			} else if _, ok := rv.(float64); !ok {
 				log.Printf("can not cast \"%v\" to float", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case int64:
+			if _, ok := lv.(int64); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(int64); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case uint64:
+			if _, ok := lv.(uint64); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(uint64); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case int32:
+			if _, ok := lv.(int32); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(int32); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case uint32:
+			if _, ok := lv.(uint32); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(uint32); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case int16:
+			if _, ok := lv.(int16); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(int16); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case uint16:
+			if _, ok := lv.(uint16); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(uint16); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case int8:
+			if _, ok := lv.(int8); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(int8); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
+				results[row] = nil
+			} else {
+				results[row] = op(lv, rv)
+			}
+		case uint8:
+			if _, ok := lv.(uint8); !ok {
+				log.Printf("can not cast \"%v\" to int", lv)
+				results[row] = nil
+			} else if _, ok := rv.(uint8); !ok {
+				log.Printf("can not cast \"%v\" to int", rv)
 				results[row] = nil
 			} else {
 				results[row] = op(lv, rv)
@@ -149,29 +239,42 @@ func applyToT(t interface{}, out chan map[uint32]interface{}, op func(l, r inter
 }
 func (lt Lt) Apply() (map[uint32]interface{}, FieldType) {
 	var (
-		t   *FieldType
-		err error
+		t       *FieldType
+		err     error
+		outType = BOOL
 	)
 	if t, err = assertTypeIn(
-		[]FieldType{INT, TIMESTAMP, FLOAT, DATE, STRING}, lt.Lhs, lt.Rhs); err != nil {
+		[]FieldType{UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64, TIMESTAMP, FLOAT32, FLOAT64, DATE, STRING}, lt.Lhs, lt.Rhs); err != nil {
 		log.Fatal(err)
 	}
 	out := make(chan map[uint32]interface{})
-	var outType FieldType
 	switch *t {
 	case STRING:
 		go applyToT("", out, func(lv, rv interface{}) interface{} { return lv.(string) < rv.(string) }, lt.Lhs, lt.Rhs)
-		outType = BOOL
-	case INT:
-		fallthrough
-	case FLOAT:
+	case UINT64:
+		go applyToT(uint64(0), out, func(l, r interface{}) interface{} { return l.(uint64) < r.(uint64) }, lt.Lhs, lt.Rhs)
+	case UINT32:
+		go applyToT(uint32(0), out, func(l, r interface{}) interface{} { return l.(uint) < r.(uint) }, lt.Lhs, lt.Rhs)
+	case UINT16:
+		go applyToT(uint16(0), out, func(l, r interface{}) interface{} { return l.(uint) < r.(uint) }, lt.Lhs, lt.Rhs)
+	case UINT8:
+		go applyToT(uint8(8), out, func(l, r interface{}) interface{} { return l.(uint) < r.(uint) }, lt.Lhs, lt.Rhs)
+	case INT64:
+		go applyToT(int64(0), out, func(l, r interface{}) interface{} { return l.(int64) < r.(int64) }, lt.Lhs, lt.Rhs)
+	case INT32:
+		go applyToT(int32(0), out, func(l, r interface{}) interface{} { return l.(int) < r.(int) }, lt.Lhs, lt.Rhs)
+	case INT16:
+		go applyToT(int16(0), out, func(l, r interface{}) interface{} { return l.(int) < r.(int) }, lt.Lhs, lt.Rhs)
+	case INT8:
+		go applyToT(int8(8), out, func(l, r interface{}) interface{} { return l.(int) < r.(int) }, lt.Lhs, lt.Rhs)
+	case FLOAT32:
+		go applyToT(float32(0), out, func(l, r interface{}) interface{} { return l.(float32) < r.(float32) }, lt.Lhs, lt.Rhs)
+	case FLOAT64:
 		go applyToT(float64(0), out, func(l, r interface{}) interface{} { return l.(float64) < r.(float64) }, lt.Lhs, lt.Rhs)
-		outType = BOOL
 	case DATE:
 		fallthrough
 	case TIMESTAMP:
 		go applyToT(time.Time{}, out, func(lv, rv interface{}) interface{} { return lv.(time.Time).Unix() < rv.(time.Time).Unix() }, lt.Lhs, lt.Rhs)
-		outType = BOOL
 	default:
 		log.Fatal("can not apply unknown in expression")
 	}
@@ -184,25 +287,38 @@ func (gt Gt) Apply() (map[uint32]interface{}, FieldType) {
 		err error
 	)
 	if t, err = assertTypeIn(
-		[]FieldType{INT, TIMESTAMP, FLOAT, DATE, STRING}, gt.Lhs, gt.Rhs); err != nil {
+		[]FieldType{UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64, TIMESTAMP, FLOAT32, FLOAT64, DATE, STRING}, gt.Lhs, gt.Rhs); err != nil {
 		log.Fatal(err)
 	}
 	out := make(chan map[uint32]interface{})
-	var outType FieldType
+	outType := BOOL
 	switch *t {
 	case STRING:
 		go applyToT("", out, func(lv, rv interface{}) interface{} { return lv.(string) > rv.(string) }, gt.Lhs, gt.Rhs)
-		outType = BOOL
-	case INT:
-		fallthrough
-	case FLOAT:
+	case UINT64:
+		go applyToT(uint64(0), out, func(l, r interface{}) interface{} { return l.(uint64) > r.(uint64) }, gt.Lhs, gt.Rhs)
+	case UINT32:
+		go applyToT(uint32(0), out, func(l, r interface{}) interface{} { return l.(uint) > r.(uint) }, gt.Lhs, gt.Rhs)
+	case UINT16:
+		go applyToT(uint16(0), out, func(l, r interface{}) interface{} { return l.(uint) > r.(uint) }, gt.Lhs, gt.Rhs)
+	case UINT8:
+		go applyToT(uint8(8), out, func(l, r interface{}) interface{} { return l.(uint) > r.(uint) }, gt.Lhs, gt.Rhs)
+	case INT64:
+		go applyToT(int64(0), out, func(l, r interface{}) interface{} { return l.(int64) > r.(int64) }, gt.Lhs, gt.Rhs)
+	case INT32:
+		go applyToT(int32(0), out, func(l, r interface{}) interface{} { return l.(int) > r.(int) }, gt.Lhs, gt.Rhs)
+	case INT16:
+		go applyToT(int16(0), out, func(l, r interface{}) interface{} { return l.(int) > r.(int) }, gt.Lhs, gt.Rhs)
+	case INT8:
+		go applyToT(int8(8), out, func(l, r interface{}) interface{} { return l.(int) > r.(int) }, gt.Lhs, gt.Rhs)
+	case FLOAT32:
+		go applyToT(float32(0), out, func(l, r interface{}) interface{} { return l.(float32) > r.(float32) }, gt.Lhs, gt.Rhs)
+	case FLOAT64:
 		go applyToT(float64(0), out, func(l, r interface{}) interface{} { return l.(float64) > r.(float64) }, gt.Lhs, gt.Rhs)
-		outType = BOOL
 	case DATE:
 		fallthrough
 	case TIMESTAMP:
 		go applyToT(time.Time{}, out, func(lv, rv interface{}) interface{} { return lv.(time.Time).Unix() > rv.(time.Time).Unix() }, gt.Lhs, gt.Rhs)
-		outType = BOOL
 	default:
 		log.Fatal("can not apply unknown in expression")
 	}
@@ -223,30 +339,42 @@ func (eq Eq) Apply() (map[uint32]interface{}, FieldType) {
 		return nm, BOOL
 	}
 	if t, err = assertTypeIn(
-		[]FieldType{INT, TIMESTAMP, FLOAT, DATE, STRING, BOOL}, eq.Lhs, eq.Rhs); err != nil {
+		[]FieldType{UINT8, UINT16, UINT32, UINT64, INT8, INT16, INT32, INT64, TIMESTAMP, FLOAT32, FLOAT64, DATE, STRING, BOOL}, eq.Lhs, eq.Rhs); err != nil {
 		log.Fatal(err)
 	}
 	out := make(chan map[uint32]interface{})
-	var outType FieldType
+	outType := BOOL
 	switch *t {
 	case STRING:
 		go applyToT("", out, func(lv, rv interface{}) interface{} { return lv.(string) == rv.(string) }, eq.Lhs, eq.Rhs)
-		outType = BOOL
-	case INT:
-		fallthrough
-	case FLOAT:
+	case UINT64:
+		go applyToT(uint64(0), out, func(l, r interface{}) interface{} { return l.(uint64) == r.(uint64) }, eq.Lhs, eq.Rhs)
+	case UINT32:
+		go applyToT(uint32(0), out, func(l, r interface{}) interface{} { return l.(uint) == r.(uint) }, eq.Lhs, eq.Rhs)
+	case UINT16:
+		go applyToT(uint16(0), out, func(l, r interface{}) interface{} { return l.(uint) == r.(uint) }, eq.Lhs, eq.Rhs)
+	case UINT8:
+		go applyToT(uint8(8), out, func(l, r interface{}) interface{} { return l.(uint) == r.(uint) }, eq.Lhs, eq.Rhs)
+	case INT64:
+		go applyToT(int64(0), out, func(l, r interface{}) interface{} { return l.(int64) == r.(int64) }, eq.Lhs, eq.Rhs)
+	case INT32:
+		go applyToT(int32(0), out, func(l, r interface{}) interface{} { return l.(int) == r.(int) }, eq.Lhs, eq.Rhs)
+	case INT16:
+		go applyToT(int16(0), out, func(l, r interface{}) interface{} { return l.(int) == r.(int) }, eq.Lhs, eq.Rhs)
+	case INT8:
+		go applyToT(int8(8), out, func(l, r interface{}) interface{} { return l.(int) == r.(int) }, eq.Lhs, eq.Rhs)
+	case FLOAT32:
+		go applyToT(float32(0), out, func(l, r interface{}) interface{} { return l.(float32) == r.(float32) }, eq.Lhs, eq.Rhs)
+	case FLOAT64:
 		go applyToT(float64(0), out, func(l, r interface{}) interface{} { return l.(float64) == r.(float64) }, eq.Lhs, eq.Rhs)
-		outType = BOOL
 	case DATE:
 		fallthrough
 	case TIMESTAMP:
 		go applyToT(time.Time{}, out, func(lv, rv interface{}) interface{} { return lv.(time.Time).Unix() == rv.(time.Time).Unix() }, eq.Lhs, eq.Rhs)
-		outType = BOOL
 	case BOOL:
 		go applyToT(true, out, func(l, r interface{}) interface{} {
 			return l.(bool) == r.(bool)
 		}, eq.Lhs, eq.Rhs)
-		outType = BOOL
 	default:
 		log.Fatal("can not apply unknown in expression")
 	}

--- a/test/etl_csv_test.go
+++ b/test/etl_csv_test.go
@@ -590,7 +590,7 @@ func filingtracker(testFile string) (Composer, error) {
 		STRING,
 		nullable)
 	floatNilable, err := types.NewField(
-		FLOAT,
+		FLOAT32,
 		nullable)
 
 	reportDate := InterrogateDate(&testFile)

--- a/types/convert.go
+++ b/types/convert.go
@@ -37,19 +37,29 @@ func SimpleToString(it interface{}) *string {
 	case time.Time:
 		val = it.(time.Time).Format(time.RFC3339)
 	case float64:
-		val = fmt.Sprintf("%f", it.(float64))
+		val = fmt.Sprint(it.(float64))
 	case float32:
-		val = fmt.Sprintf("%f", it.(float32))
+		val = fmt.Sprint(it.(float32))
+	case uint:
+		val = fmt.Sprint(it.(uint))
+	case uint64:
+		val = fmt.Sprint(it.(uint64))
+	case uint32:
+		val = fmt.Sprint(it.(uint32))
+	case uint16:
+		val = fmt.Sprint(it.(uint16))
+	case uint8:
+		val = fmt.Sprint(it.(uint8))
 	case int:
-		val = strconv.Itoa(it.(int))
+		val = fmt.Sprint(it.(int))
 	case int64:
-		val = strconv.FormatInt(it.(int64), 10)
+		val = fmt.Sprint(it.(int64))
 	case int32:
-		val = strconv.Itoa(it.(int))
+		val = fmt.Sprint(it.(int32))
 	case int16:
-		val = strconv.Itoa(it.(int))
+		val = fmt.Sprint(it.(int16))
 	case int8:
-		val = strconv.Itoa(it.(int))
+		val = fmt.Sprint(it.(int8))
 	default:
 		pkg.LogDefect(pkg.Defect{
 			Msg: fmt.Sprintf("can not convert \"%v\" to string", it),
@@ -92,24 +102,136 @@ func BoolConverter(in *string, _ ...interface{}) (interface{}, error) {
 	return false, errors.New(fmt.Sprintf("types/convert: Unable to parse %s to bool", value))
 }
 
-// Convert a field's value to an int64.
-func IntConverter(in *string, _ ...interface{}) (interface{}, error) {
-	rmSpecialChars := specialChars.ReplaceAllString(*in, "")
-	out, err := strconv.ParseInt(rmSpecialChars, 10, 64)
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("can not convert \"%s\" to int, parsing error: %s", *in, err.Error()))
+func int8Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base int64
+	if base, err = strconv.ParseInt(specialChars.ReplaceAllString(*in, ""), 10, 8); err != nil {
+		return
 	}
-	return out, nil
+	out = int8(base)
+	return
+}
+func int16Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base int64
+	if base, err = strconv.ParseInt(specialChars.ReplaceAllString(*in, ""), 10, 16); err != nil {
+		return
+	}
+	out = int16(base)
+	return
+}
+func int32Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base int64
+	if base, err = strconv.ParseInt(specialChars.ReplaceAllString(*in, ""), 10, 32); err != nil {
+		return
+	}
+	out = int32(base)
+	return
+}
+func int64Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base int64
+	if base, err = strconv.ParseInt(specialChars.ReplaceAllString(*in, ""), 10, 64); err != nil {
+		return
+	}
+	out = base
+	return
+}
+func uint8Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base uint64
+	if base, err = strconv.ParseUint(specialChars.ReplaceAllString(*in, ""), 10, 8); err != nil {
+		return
+	}
+	out = uint8(base)
+	return
+}
+func uint16Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base uint64
+	if base, err = strconv.ParseUint(specialChars.ReplaceAllString(*in, ""), 10, 16); err != nil {
+		return
+	}
+	out = uint16(base)
+	return
+}
+func uint32Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base uint64
+	if base, err = strconv.ParseUint(specialChars.ReplaceAllString(*in, ""), 10, 32); err != nil {
+		return
+	}
+	out = uint32(base)
+	return
+}
+func uint64Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base uint64
+	if base, err = strconv.ParseUint(specialChars.ReplaceAllString(*in, ""), 10, 64); err != nil {
+		return
+	}
+	out = base
+	return
+}
+
+// Convert a field's value to an int64.
+func IntConverter(t pkg.FieldType) pkg.FieldLevelConverter {
+	switch t {
+	case pkg.INT8:
+		return int8Converter
+	case pkg.INT16:
+		return int16Converter
+	case pkg.INT:
+		fallthrough
+	case pkg.INT32:
+		return int32Converter
+	case pkg.INT64:
+		return int64Converter
+	case pkg.UINT8:
+		return uint8Converter
+	case pkg.UINT16:
+		return uint16Converter
+	case pkg.UINT:
+		fallthrough
+	case pkg.UINT32:
+		return uint32Converter
+	case pkg.UINT64:
+		return uint64Converter
+	default:
+		panic(fmt.Sprintf("types/convert: Int %s not supported", t.String()))
+	}
 }
 
 // Convert a field's value to an float64.
-func FloatConverter(in *string, _ ...interface{}) (interface{}, error) {
+func float32Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base float64
 	rmSpecialChars := specialChars.ReplaceAllString(*in, "")
-	out, err := strconv.ParseFloat(rmSpecialChars, 64)
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("can not convert \"%s\" to float, parsing error: %s", *in, err.Error()))
+	if base, err = strconv.ParseFloat(rmSpecialChars, 32); err != nil {
+		return
+	} else {
+		out = float32(base)
 	}
-	return out, nil
+	return out, err
+}
+
+// Convert a field's value to an float64.
+func float64Converter(in *string, _ ...interface{}) (out interface{}, err error) {
+	var base float64
+	rmSpecialChars := specialChars.ReplaceAllString(*in, "")
+	if base, err = strconv.ParseFloat(rmSpecialChars, 64); err != nil {
+		return
+	} else {
+		out = base
+	}
+	return out, err
+}
+
+// Convert a field's value to an float64.
+func FloatConverter(t pkg.FieldType) pkg.FieldLevelConverter {
+	switch t {
+	case pkg.FLOAT32:
+		return float32Converter
+	case pkg.FLOAT:
+		fallthrough
+	case pkg.FLOAT64:
+		return float64Converter
+	default:
+		panic(fmt.Sprintf("types/convert: float %s not supported", t.String()))
+	}
+
 }
 
 // Convert a field's value to an time instance.

--- a/types/convert.go
+++ b/types/convert.go
@@ -51,7 +51,7 @@ func SimpleToString(it interface{}) *string {
 	case int8:
 		val = strconv.Itoa(it.(int))
 	default:
-		pkg.LogDefect(&pkg.Defect{
+		pkg.LogDefect(pkg.Defect{
 			Msg: fmt.Sprintf("can not convert \"%v\" to string", it),
 		})
 		val = empty

--- a/types/schema.go
+++ b/types/schema.go
@@ -12,18 +12,18 @@ type (
 	}
 
 	ColumnDefinition struct {
-		Name     string
-		Field    Field
-		Unique   bool
-		Aliases  []string
-		Required bool
 		Index    uint64
+		Field    Field
+		Aliases  []string
+		Name     string
+		Unique   bool
+		Required bool
 	}
 	Schema struct {
-		columns []*ColumnDefinition
 		dupes   map[string][]int
 		headers []string
 		indices []string
+		columns []*ColumnDefinition
 	}
 
 	Opt func(schema *Schema) *Schema
@@ -84,7 +84,7 @@ func Alias(columnName string, name string) Opt {
 			}
 		}
 		if !found {
-			pkg.FatalDefect(&pkg.Defect{
+			pkg.FatalDefect(pkg.Defect{
 				Msg: fmt.Sprintf("column [ %s ] does not exist on this schema", name),
 			})
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -14,10 +14,10 @@ type (
 
 	Field struct {
 		T         pkg.FieldType
-		Nil       *pkg.Nullable
 		convert   pkg.FieldLevelConverter
 		toString  pkg.StringifyField
 		Extension pkg.FieldExtension
+		Nil       *pkg.Nullable
 	}
 )
 
@@ -168,7 +168,7 @@ func NewField(fieldType pkg.FieldType, nullable *pkg.Nullable, opts ...FieldOver
 	}
 	for _, opt := range opts {
 		if fieldWithOpt, err := opt(&field); err != nil {
-			pkg.FatalDefect(&pkg.Defect{
+			pkg.FatalDefect(pkg.Defect{
 				Msg: err.Error(),
 			})
 		} else {

--- a/types/types.go
+++ b/types/types.go
@@ -150,12 +150,34 @@ func NewField(fieldType pkg.FieldType, nullable *pkg.Nullable, opts ...FieldOver
 	} else {
 		field.toString = SimpleToString
 		switch field.T {
+		case pkg.INT8:
+			field.convert = IntConverter(pkg.INT8)
+		case pkg.INT16:
+			field.convert = IntConverter(pkg.INT16)
 		case pkg.INT:
-			field.convert = IntConverter
+			fallthrough
+		case pkg.INT32:
+			field.convert = IntConverter(pkg.INT32)
+		case pkg.INT64:
+			field.convert = IntConverter(pkg.INT64)
+		case pkg.UINT8:
+			field.convert = IntConverter(pkg.UINT8)
+		case pkg.UINT16:
+			field.convert = IntConverter(pkg.UINT16)
+		case pkg.UINT:
+			fallthrough
+		case pkg.UINT32:
+			field.convert = IntConverter(pkg.UINT32)
+		case pkg.UINT64:
+			field.convert = IntConverter(pkg.UINT64)
 		case pkg.BOOL:
 			field.convert = BoolConverter
+		case pkg.FLOAT32:
+			field.convert = FloatConverter(pkg.FLOAT32)
 		case pkg.FLOAT:
-			field.convert = FloatConverter
+			fallthrough
+		case pkg.FLOAT64:
+			field.convert = FloatConverter(pkg.FLOAT64)
 		case pkg.TIMESTAMP:
 			fallthrough
 		case pkg.DATE:


### PR DESCRIPTION
This commit adds more granular numeric types, uses copies instead of references to nodes where ownership should not be passed, updates node.Children to return a reference to the child for size reasons(children can be large, avoid copy), add default value and type to new node constructor, replace slice with fixed size array where possible.